### PR TITLE
Stop hardcoding server URL in frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ desktop.ini
 *.pid
 *.seed
 *.pid.lock
+
+.env


### PR DESCRIPTION
created .env file where we must add the server URL, and added .env to .gitignore